### PR TITLE
Background Execution of sudo systemctl reload-or-restart or restart gives a false impression

### DIFF
--- a/.onionrc
+++ b/.onionrc
@@ -181,14 +181,18 @@ restarting_tor()
 {
   set_owner_permission
   if [ "${1}" = "force" ]; then
-    printf "\n# Restarting tor...\n"
-    sudo systemctl restart "${TOR_SERVICE}" &
-    sleep 2
+    printf "\n# Restarting tor, please be patient.\n"
+    printf "\n# Getting stuck after several minutes? Press CTR-C\n"
+    printf "\n# and use onionservice-cli setup torrc to restore \n"
+    printf "\n# the latest torrc.\n"
+    sudo systemctl restart "${TOR_SERVICE}"
     printf %s"${FOREGROUND_GREEN}# Restarted tor succesfully!\n${UNSET_FORMAT}"
   elif [ "${1}" = "" ]; then
-    printf "\n# Reloading tor...\n"
-    sudo systemctl reload-or-restart "${TOR_SERVICE}" &
-    sleep 2
+    printf "\n# Reloading tor, please be patient.\n"
+    printf "\n# Getting stuck after several minutes? Press CTR-C\n"
+    printf "\n# and use onionservice-cli setup torrc to restore \n"
+    printf "\n# the latest torrc.\n"
+    sudo systemctl reload-or-restart "${TOR_SERVICE}"
     printf %s"${FOREGROUND_GREEN}# Reloaded tor succesfully!\n${UNSET_FORMAT}"
   fi
 }


### PR DESCRIPTION
**Related issue.**
#1 

**Describe the changes**
- The user is informed that restarting or reloading tor will take a moment and what he could do if it gets stuck.
- Restart or reload-or-restart took back as a foreground process.
- Removed the two seconds of sleep.

**Additional context**
Have currently no installation to test it!
